### PR TITLE
Add clocksource=tsc to EC2 grub config

### DIFF
--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -4,7 +4,7 @@ set oem_id="ec2"
 
 # Blacklist the Xen framebuffer module so it doesn't get loaded at boot
 # Disable `ens3` style names, so eth0 is used for both ixgbevf or xen.
-set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0 transparent_hugepage=never"
+set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0 transparent_hugepage=never clocksource=tsc"
 
 if [ "$grub_platform" = pc ]; then
 	set linux_console="console=ttyS0,115200n8"

--- a/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
+++ b/coreos-base/oem-ec2-compat/files/grub-ec2.cfg
@@ -4,7 +4,7 @@ set oem_id="ec2"
 
 # Blacklist the Xen framebuffer module so it doesn't get loaded at boot
 # Disable `ens3` style names, so eth0 is used for both ixgbevf or xen.
-set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0 transparent_hugepage=never clocksource=tsc"
+set linux_append="modprobe.blacklist=xen_fbfront net.ifnames=0 transparent_hugepage=never clocksource=tsc tsc=reliable"
 
 if [ "$grub_platform" = pc ]; then
 	set linux_console="console=ttyS0,115200n8"


### PR DESCRIPTION
https://software.intel.com/en-us/blogs/2013/06/20/eliminate-the-dreaded-clocksource-is-unstable-message-switch-to-tsc-for-a-stable as well as numerous EC2 recommendations
https://www.youtube.com/watch?v=7Cyd22kOqWc and others